### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/thirdparty/hbase-1.0.0-cdh5.5.0-SNAPSHOT/pom.xml
+++ b/thirdparty/hbase-1.0.0-cdh5.5.0-SNAPSHOT/pom.xml
@@ -1096,7 +1096,7 @@
     <commons-math.version>2.1</commons-math.version>
     <commons-net.version>3.1</commons-net.version>
     <disruptor.version>3.3.0</disruptor.version>
-    <collections.version>3.2.1</collections.version>
+    <collections.version>3.2.2</collections.version>
     <httpclient.version>3.1</httpclient.version>
     <metrics-core.version>2.2.0</metrics-core.version>
     <guava.version>12.0.1</guava.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
